### PR TITLE
fix: 웹뷰가 백그라운드에서 강제 종료되어 흰 화면이 되는 이슈 수정

### DIFF
--- a/ios/spurtRN.xcodeproj/project.pbxproj
+++ b/ios/spurtRN.xcodeproj/project.pbxproj
@@ -296,7 +296,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -334,7 +334,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -418,10 +418,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -490,10 +487,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/src/screens/WebViewScreen.tsx
+++ b/src/screens/WebViewScreen.tsx
@@ -295,9 +295,10 @@ export default function WebViewScreen({
         sharedCookiesEnabled={true}
         domStorageEnabled={true}
         injectedJavaScript={injectedJS}
-        bounces={false} // 아이폰 스크롤 시 bounce 효과 방지
+        bounces={false}
         allowsInlineMediaPlayback={true}
         pullToRefreshEnabled={false}
+        onContentProcessDidTerminate={() => webViewRef.current?.reload()}
       />
     </View>
   );


### PR DESCRIPTION
### Description

iOS 웹뷰가 많은 리소스를 사용할 경우, 앱이 멈추는 문제를 수정합니다.
백그라운드에서 오랜시간 켜놓았을 때, 흰 화면이 발생하는 문제가 있었습니다. 

웹뷰 프로세스가 종료되어 발생하는 현상이었고, 프로세스가 종료되었을 때, 
`reload`를 시키는 방향으로 문제를 해결합니다.